### PR TITLE
fix: fix unstable tests by isolating JVM forks

### DIFF
--- a/route-registration/route-registration-common-spring/pom.xml
+++ b/route-registration/route-registration-common-spring/pom.xml
@@ -106,4 +106,17 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Fork each test class in separate JVM to isolate RxJava schedulers -->
+                    <reuseForks>false</reuseForks>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/route-registration/route-registration-common-spring/src/test/java/com/netcracker/cloud/routesregistration/common/spring/gateway/route/RoutesRestRegistrationProcessorTest.java
+++ b/route-registration/route-registration-common-spring/src/test/java/com/netcracker/cloud/routesregistration/common/spring/gateway/route/RoutesRestRegistrationProcessorTest.java
@@ -9,7 +9,6 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import com.netcracker.cloud.restclient.MicroserviceRestClient;
 import com.netcracker.cloud.routesregistration.common.gateway.route.ControlPlaneClient;
@@ -98,33 +97,43 @@ class RoutesRestRegistrationProcessorTest {
     void postRoutes() throws Exception {
         Collection<RouteEntry> routes = routeAnnotationProcessor.scanForRoutes();
 
-        startRoutesPostingThreads(routes);
-
         int postRequestsCount = POST_ROUTES_CALLS_NUMBER * RoutesTestConfiguration.THREADS_NUM;
 
+        // Enqueue mock responses BEFORE starting async requests
         for (int i = 0; i < postRequestsCount; i++) {
             server.enqueue(new MockResponse().setResponseCode(201));
         }
-        List<RecordedRequest> recordedRequests = new ArrayList<>(server.getRequestCount());
+
+        startRoutesPostingThreads(routes);
+
+        List<RecordedRequest> recordedRequests = new ArrayList<>(postRequestsCount);
         for (int i = 0; i < postRequestsCount; i++) {
-            recordedRequests.add(server.takeRequest(2, TimeUnit.MINUTES));
+            RecordedRequest request = server.takeRequest(2, TimeUnit.MINUTES);
+            recordedRequests.add(request);
         }
-        assertEquals(postRequestsCount, server.getRequestCount());
+
+        assertEquals(postRequestsCount, server.getRequestCount(),
+                String.format("Expected %d requests but got %d", postRequestsCount, server.getRequestCount()));
 
         List<RouteConfigurationRequestV3> recordedRequestBodies = readRequests(recordedRequests);
 
         List<RouteConfigurationRequestV3> publicGroup = recordedRequestBodies.stream()
-                .filter(recordedRequest -> recordedRequest.getGateways().get(0).equals(RoutesTestConfiguration.PUBLIC_NODE_GROUP))
-                .collect(Collectors.toList());
+                .filter(recordedRequest -> recordedRequest.getGateways().getFirst().equals(RoutesTestConfiguration.PUBLIC_NODE_GROUP))
+                .toList();
         List<RouteConfigurationRequestV3> privateGroup = recordedRequestBodies.stream()
-                .filter(recordedRequest -> recordedRequest.getGateways().get(0).equals(RoutesTestConfiguration.PRIVATE_NODE_GROUP))
-                .collect(Collectors.toList());
+                .filter(recordedRequest -> recordedRequest.getGateways().getFirst().equals(RoutesTestConfiguration.PRIVATE_NODE_GROUP))
+                .toList();
         List<RouteConfigurationRequestV3> internalGroup = recordedRequestBodies.stream()
-                .filter(recordedRequest -> recordedRequest.getGateways().get(0).equals(RoutesTestConfiguration.INTERNAL_NODE_GROUP))
-                .collect(Collectors.toList());
-        assertTrue(publicGroup.size() > 2);
-        assertTrue(privateGroup.size() > 2);
-        assertTrue(internalGroup.size() > 2);
+                .filter(recordedRequest -> recordedRequest.getGateways().getFirst().equals(RoutesTestConfiguration.INTERNAL_NODE_GROUP))
+                .toList();
+
+
+        assertTrue(publicGroup.size() >= RoutesTestConfiguration.THREADS_NUM,
+                String.format("publicGroup.size()=%d, expected >= %d", publicGroup.size(), RoutesTestConfiguration.THREADS_NUM));
+        assertTrue(privateGroup.size() >= RoutesTestConfiguration.THREADS_NUM,
+                String.format("privateGroup.size()=%d, expected >= %d", privateGroup.size(), RoutesTestConfiguration.THREADS_NUM));
+        assertTrue(internalGroup.size() >= RoutesTestConfiguration.THREADS_NUM,
+                String.format("internalGroup.size()=%d, expected >= %d", internalGroup.size(), RoutesTestConfiguration.THREADS_NUM));
     }
 
     private List<RouteConfigurationRequestV3> readRequests(List<RecordedRequest> requests) {

--- a/route-registration/route-registration-common/pom.xml
+++ b/route-registration/route-registration-common/pom.xml
@@ -61,4 +61,17 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Fork each test class in separate JVM to isolate RxJava schedulers -->
+                    <reuseForks>false</reuseForks>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
## RCA
`RouteRetryManager` uses global RxJava schedulers (`Schedulers.single()` for internal coordination and `Schedulers.computation()` / `Schedulers.newThread()` for task execution).

 `RouteRetryManagerTest` intentionally creates tasks that throw exceptions and retry indefinitely. These tasks continue running even after the test completes, because RxJava schedulers are global (JVM-level singletons). When subsequent tests like `RoutesRestRegistrationProcessorTest` run in the same JVM, they inherit polluted scheduler state, causing race conditions and timeouts.

Additionally, `RoutesRestRegistrationProcessorTest` had two bugs:
  1. Mock responses were enqueued after starting async requests (race condition)
  2. Assertion `size() > 2` failed on CI machines with 2 CPU cores

## Solution

  1. JVM isolation: Added `<reuseForks>false</reuseForks>` to surefire plugin in both `route-registration-common` and `route-registration-common-spring modules`. Each test class now runs in a separate JVM, guaranteeing clean
  scheduler state.
  2. Fixed race condition: Moved `server.enqueue()` calls before `startRoutesPostingThreads()` to ensure mock responses are ready before async requests start.
  3. Fixed assertion: Changed `size() > 2` to `size() >= THREADS_NUM` to work correctly regardless of CPU core count.
